### PR TITLE
[김동규] #4 서울시 공공데이터 반환 API 기능 일부 수정 및 테스트코드 작성 

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,467 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+from unittest      import mock
+from unittest.mock import patch
+
+from rest_framework.test import APITestCase
+
+
+class SeoulOpenDataTest(APITestCase):
+    
+    maxDiff = None
+    
+    def test_success_seoul_data_gubn_code_01(self):
+        gubn     = '종로'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+    
+    def test_success_seoul_data_gubn_code_02(self):
+        gubn     = '중'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_03(self):
+        gubn     = '용산'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_04(self):
+        gubn     = '성동'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_05(self):
+        gubn     = '광진'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_06(self):
+        gubn     = '동대문'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_07(self):
+        gubn     = '중랑'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_08(self):
+        gubn     = '성북'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_09(self):
+        gubn     = '강북'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_10(self):
+        gubn     = '도봉'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_11(self):
+        gubn     = '노원'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_12(self):
+        gubn     = '은평'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_13(self):
+        gubn     = '서대문'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+
+    def test_success_seoul_data_gubn_code_14(self):
+        gubn     = '마포'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_15(self):
+        gubn     = '양천'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_16(self):
+        gubn     = '강서'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_17(self):
+        gubn     = '구로'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_18(self):
+        gubn     = '금천'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_19(self):
+        gubn     = '영등포'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_20(self):
+        gubn     = '동작'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_21(self):
+        gubn     = '관악'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_22(self):
+        gubn     = '서초'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_23(self):
+        gubn     = '강남'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_24(self):
+        gubn     = '송파'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_success_seoul_data_gubn_code_25(self):
+        gubn     = '강동'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(gubn, response.json()['gu_name'])
+        self.assertEqual(float, type(response.json()['avg_water_level']))
+        self.assertEqual(float, type(response.json()['raingauge_info'][0]['sum_rain_fall']))
+        self.assertIn('gu_name', response.json())
+        self.assertIn('avg_water_level', response.json())
+        self.assertIn('raingauge_info', response.json())
+        self.assertIn('raingauge_name', response.json()['raingauge_info'][0])
+        self.assertIn('sum_rain_fall', response.json()['raingauge_info'][0])
+        
+    def test_fail_seoul_data_due_to_no_gubn_param(self):
+        response = self.client\
+                       .get('/api/seoul/sewerlevel-rainfall?gubn=', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '구이름을 입력하세요.'
+            }
+        )
+        
+    def test_fail_seoul_data_due_to_gubn_param_not_existed(self):
+        gubn     = '우리집'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': f'{gubn}구 지역은 존재하지 않습니다.'
+            }
+        )
+    
+    @patch('core.sewer_pipe.requests')
+    def test_fail_seoul_data_due_to_sewer_pipe_open_api_error(self, mocked_requests):
+        
+        class MockedResponse:
+            data = {
+                'DrainpipeMonitoringInfo':
+                    {'RESULT': 
+                        {'CODE': 'ERROR-500',\
+                            'MESSAGE': '서버 오류입니다. 지속적으로 발생시 열린 데이터 광장으로 문의(Q&A) 바랍니다.'
+                    }
+                }
+            }
+            content = json.dumps(data)
+            
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        gubn     = '종로'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '서울시 해당지역의 공공데이터를 찾지 못했습니다.'
+            }    
+        )
+        
+    @patch('core.rainfall.requests')
+    def test_fail_seoul_data_due_to_rainfall_open_api_error(self, mocked_requests):
+        
+        class MockedResponse:
+            data = {
+                'ListRainfallService':
+                    {'RESULT': 
+                        {'CODE': 'ERROR-500',\
+                            'MESSAGE': '서버 오류입니다. 지속적으로 발생시 열린 데이터 광장으로 문의(Q&A) 바랍니다.'
+                    }
+                }
+            }
+            content = json.dumps(data)
+            
+        mocked_requests.get = mock.MagicMock(return_value = MockedResponse())
+        
+        gubn     = '종로'
+        response = self.client\
+                       .get(f'/api/seoul/sewerlevel-rainfall?gubn={gubn}', content_type='application/json')
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                'detail': '서울시 해당지역의 공공데이터를 찾지 못했습니다.'
+            }    
+        )    

--- a/api/views.py
+++ b/api/views.py
@@ -93,4 +93,4 @@ class SeoulOpenDataVeiw(APIView):
             return Response(serializer.errors, status=400)
         
         except KeyError:
-            return Response({'detail': 'key error'}, status=400)   
+            return Response({'detail': f'서울시 {gubn}구의 공공데이터 조회를 실패했습니다.'}, status=400)   


### PR DESCRIPTION
<!--PR 제목 : [ 이름 ] #이슈번호 - 구현 내용 -->

# 구현 목표
<!-- 이슈 번호 맵핑해주세요. 간단한 요약을 해주세요.-->
- #4 
- 서울시 Open API를 활용한 공공데이터 제공 API 기능 일부 수정
- 테스트 코드 작성(성공/실패)

# 변경 사항
<!--관련 없는 내용을 지워주세요-->

- [x] 기능 추가
- [ ] 셋업 
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드리뷰 반영
- [ ] 컨벤션 수정
- [ ] 레거시코드 제거 및 Breaking

<!--⬇ 변경사항을 자세히 작성합니다. ⬇-->
- 서울시 Open API의 데이터가 문제가 있을 때의 예외처리 메세지 수정
- 모든 지역에 대한 테스트코드(성공) 작성
- 해당 API에 존재하는 모든 예외처리에 대해 테스트코드(실패) 작성


# 테스트 여부
<!--테스트 통과 여부를 체크해주세요-->
- [x] TEST 

# 스크린샷 
<!--필요한 경우 첨부합니다-->
<img width="957" alt="스크린샷 2022-07-08 06 48 39" src="https://user-images.githubusercontent.com/89829943/177877345-da55f6f4-a241-4029-b276-ae80b8b9b7cb.png">

